### PR TITLE
Added URL to docs.primo.io in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ prototype-documentation
 =======================
 
 DIY Instructions on how to make your own Primo prototype.
+
+Get Started Here: [http://docs.primo.io](http://docs.primo.io)


### PR DESCRIPTION
Just making it easy to find the documentation page from the Github repo ;-)
